### PR TITLE
Modifications so app and html pages properly use RAILS_RELATIVE_URL_ROOT

### DIFF
--- a/app/views/api/v2/demos/show.html.erb
+++ b/app/views/api/v2/demos/show.html.erb
@@ -32,7 +32,7 @@
 </h2>
 
 <div id="form_container">
-	<%= form_tag("/api/v2/translator", id: "submitJSON") do %>
+	<%= form_tag((ENV['RAILS_RELATIVE_URL_ROOT'] ? ENV['RAILS_RELATIVE_URL_ROOT'] : "") + "/api/v2/translator", id: "submitJSON") do %>
 		<div class="form_description">
 			<h2>Submit Version 2 mdJson</h2>
 			<p>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -15,7 +15,7 @@
 </h2>
 
 <%
-doc = <<-MARKDOWN
+doc = <<-MARKDOWN.gsub(/APP_ROOT/, ENV['RAILS_RELATIVE_URL_ROOT'] || '')
 
 ## Welcome to the mdTranslator
 
@@ -26,10 +26,10 @@ receives output in one of the mdTranslator's supported 'writer' formats.
 
 ## Links
 
- * Documentation of the mdTranslator's [API](./api/apis) for versions 1 and 2
- * List of supported mdTranslator [readers](./api/readers)
- * List of supported mdTranslator [writers](./api/writers)
- * Hosted [demo](./api/v2/demo) of mdTranslator V2 and it's options
+ * Documentation of the mdTranslator's [API](APP_ROOT/api/apis) for versions 1 and 2
+ * List of supported mdTranslator [readers](APP_ROOT/api/readers)
+ * List of supported mdTranslator [writers](APP_ROOT/api/writers)
+ * Hosted [demo](APP_ROOT/api/v2/demo) of mdTranslator V2 and it's options
  * Other Links ...
    - [Home page](http://www.adiwg.org/mdTranslator/) for the mdTranslator project
    - Online [mdTool](http://mdTools.adiwg.org/) for viewing the latest mdJson schema

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,7 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run Rails.application
+
+map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do
+    run Rails.application
+end


### PR DESCRIPTION
To deploy in my environment, we have to set a relative root (i.e. dev-sciencebase.usgs.gov/mdTranslator). These changes were necessary to get the app to fully honor the RAILS_RELATIVE_URL_ROOT variable.